### PR TITLE
Add tests and implementation for parsing MusicXML

### DIFF
--- a/Engine.Tests/Assets/Bare_Score.musicxml
+++ b/Engine.Tests/Assets/Bare_Score.musicxml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/Engine.Tests/Assets/Bare_Score_With_Skeleton.musicxml
+++ b/Engine.Tests/Assets/Bare_Score_With_Skeleton.musicxml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.1 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work></work>
+  <identification></identification>
+  <encoding></encoding>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Music</part-name>
+    </score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>1</divisions>
+        <key>
+          <fifths>0</fifths>
+        </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+        </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+        </clef>
+      </attributes>
+    </measure>
+  </part>
+</score-partwise>

--- a/Engine.Tests/Assets/Etude_No._1.musicxml
+++ b/Engine.Tests/Assets/Etude_No._1.musicxml
@@ -1,0 +1,1158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Etude No. 1</work-title>
+    </work>
+  <identification>
+    <creator type="composer">James Hewitt</creator>
+    <encoding>
+      <software>MuseScore 3.2.3</software>
+      <encoding-date>2019-10-09</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1584</page-height>
+      <page-width>1224</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="612" default-y="1527.31" justify="center" valign="top" font-size="24">Etude No. 1</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1167.31" default-y="1427.31" justify="right" valign="bottom" font-size="12">Alan Turing
+</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="133.88">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <divisions>96</divisions>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        <time>
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="83.07" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="2" width="187.38">
+      <note default-x="10.00" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="41.77" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="69.08" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        </note>
+      <note default-x="92.30" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>24</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note default-x="111.42" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>12</duration>
+        <voice>1</voice>
+        <type>32nd</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        <beam number="3">begin</beam>
+        </note>
+      <note default-x="127.09" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>6</duration>
+        <voice>1</voice>
+        <type>64th</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        <beam number="3">continue</beam>
+        <beam number="4">begin</beam>
+        </note>
+      <note default-x="142.75" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>128th</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        <beam number="3">end</beam>
+        <beam number="4">end</beam>
+        <beam number="5">backward hook</beam>
+        </note>
+      <note>
+        <rest/>
+        <duration>3</duration>
+        <voice>1</voice>
+        <type>128th</type>
+        </note>
+      </measure>
+    <measure number="3" width="66.09">
+      <note default-x="13.80" default-y="-85.00">
+        <pitch>
+          <step>C</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <note default-x="13.80" default-y="-75.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <note default-x="13.80" default-y="-65.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <note default-x="13.80" default-y="-50.00">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="4" width="85.95">
+      <note default-x="10.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="10.00" default-y="-25.00">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="22.59" default-y="-20.00">
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note>
+        <rest/>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        </note>
+      <backup>
+        <duration>192</duration>
+        </backup>
+      <note default-x="47.00" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="47.00" default-y="-20.00">
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="47.00" default-y="-5.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="5" width="173.85">
+      <note default-x="10.00" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <slur type="start" placement="below" number="1"/>
+          </notations>
+        </note>
+      <note default-x="30.32" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note default-x="50.65" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <slur type="start" placement="below" number="1"/>
+          </notations>
+        </note>
+      <note default-x="70.97" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <slur type="stop" number="1"/>
+          <slur type="start" placement="below" number="1"/>
+          </notations>
+        </note>
+      <note default-x="91.29" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <notations>
+          <slur type="stop" number="1"/>
+          </notations>
+        </note>
+      <note default-x="116.57" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="149.08" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="6" width="98.44">
+      <note default-x="13.80" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <notations>
+          <tuplet type="start" bracket="yes"/>
+          </notations>
+        </note>
+      <note default-x="41.36" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        </note>
+      <note default-x="68.92" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>128</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <time-modification>
+          <actual-notes>3</actual-notes>
+          <normal-notes>2</normal-notes>
+          </time-modification>
+        <stem>up</stem>
+        <notations>
+          <tuplet type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="7" width="183.87">
+      <note default-x="10.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <attributes>
+        <clef>
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="62.58" default-y="30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="99.15" default-y="35.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      <attributes>
+        <clef>
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        </attributes>
+      <note default-x="145.71" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>1</voice>
+        <type>quarter</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="8" width="181.15">
+      <note default-x="10.36" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <backup>
+        <duration>96</duration>
+        </backup>
+      <forward>
+        <duration>96</duration>
+        </forward>
+      <note default-x="95.57" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <accidental>natural</accidental>
+        <stem>up</stem>
+        </note>
+      <barline location="right">
+        <bar-style>light-light</bar-style>
+        </barline>
+      </measure>
+    <measure number="9" width="113.58">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <system-distance>150.00</system-distance>
+          </system-layout>
+        </print>
+      <attributes>
+        <key>
+          <fifths>0</fifths>
+          </key>
+        </attributes>
+      <note default-x="68.17" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="10" width="125.06">
+      <attributes>
+        <time>
+          <beats>12</beats>
+          <beat-type>8</beat-type>
+          </time>
+        </attributes>
+      <note default-x="42.37" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="69.28" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="96.19" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="11" width="77.71">
+      <attributes>
+        <time symbol="common">
+          <beats>4</beats>
+          <beat-type>4</beat-type>
+          </time>
+        </attributes>
+      <note default-x="32.31" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="12" width="74.22">
+      <note default-x="32.80" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <accidental>flat</accidental>
+        </note>
+      <note default-x="32.80" default-y="-5.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <alter>1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <accidental>sharp</accidental>
+        </note>
+      </measure>
+    <measure number="13" width="60.67">
+      <note default-x="10.00" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <ornaments>
+            <trill-mark/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    <measure number="14" width="60.67">
+      <note default-x="10.00" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <ornaments>
+            <turn/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    <measure number="15" width="60.01">
+      <note default-x="13.32" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <ornaments>
+            <inverted-turn/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    <measure number="16" width="60.01">
+      <note default-x="13.32" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <ornaments>
+            <inverted-mordent/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    <measure number="17" width="60.67">
+      <note default-x="13.80" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <ornaments>
+            <mordent/>
+            </ornaments>
+          </notations>
+        </note>
+      </measure>
+    <measure number="18" width="75.59">
+      <note default-x="11.75" default-y="-45.00">
+        <grace slash="yes"/>
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="30.19" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      </measure>
+    <measure number="19" width="200.72">
+      <note default-x="13.80" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">begin</beam>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note default-x="37.07" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note default-x="60.01" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">continue</beam>
+        <notations>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note default-x="82.95" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <tie type="stop"/>
+        <tie type="start"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <beam number="1">end</beam>
+        <notations>
+          <tied type="stop"/>
+          <tied type="start"/>
+          </notations>
+        </note>
+      <note default-x="105.89" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>48</duration>
+        <tie type="stop"/>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <notations>
+          <tied type="stop"/>
+          </notations>
+        </note>
+      <note>
+        <rest/>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        </note>
+      <note>
+        <rest/>
+        <duration>48</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        </note>
+      </measure>
+    <measure number="20" width="68.49">
+      <note default-x="23.09" default-y="-50.00">
+        <pitch>
+          <step>C</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate default-x="-19.73" default-y="-9.49"/>
+          </notations>
+        </note>
+      <note default-x="23.09" default-y="-40.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate default-x="-19.73" default-y="-9.49"/>
+          </notations>
+        </note>
+      <note default-x="23.09" default-y="-30.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate default-x="-19.73" default-y="-9.49"/>
+          </notations>
+        </note>
+      <note default-x="23.09" default-y="-15.00">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate default-x="-19.73" default-y="-9.49"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="21" width="73.21">
+      <note default-x="27.81" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="up" default-x="-24.45" default-y="-4.49"/>
+          </notations>
+        </note>
+      <note default-x="27.81" default-y="-35.00">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="up" default-x="-24.45" default-y="-4.49"/>
+          </notations>
+        </note>
+      <note default-x="27.81" default-y="-25.00">
+        <chord/>
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="up" default-x="-24.45" default-y="-4.49"/>
+          </notations>
+        </note>
+      <note default-x="27.81" default-y="-10.00">
+        <chord/>
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="up" default-x="-24.45" default-y="-4.49"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="22" width="247.60">
+      <print new-system="yes">
+        <system-layout>
+          <system-margins>
+            <left-margin>0.00</left-margin>
+            <right-margin>-0.00</right-margin>
+            </system-margins>
+          <system-distance>150.00</system-distance>
+          </system-layout>
+        </print>
+      <note default-x="75.99" default-y="-40.00">
+        <pitch>
+          <step>E</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="down" default-x="-24.46" default-y="0.51"/>
+          </notations>
+        </note>
+      <note default-x="75.99" default-y="-30.00">
+        <chord/>
+        <pitch>
+          <step>G</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="down" default-x="-24.46" default-y="0.51"/>
+          </notations>
+        </note>
+      <note default-x="75.99" default-y="-20.00">
+        <chord/>
+        <pitch>
+          <step>B</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="down" default-x="-24.46" default-y="0.51"/>
+          </notations>
+        </note>
+      <note default-x="75.99" default-y="-5.00">
+        <chord/>
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        <notations>
+          <arpeggiate direction="down" default-x="-24.46" default-y="0.51"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="23" width="209.64">
+      <note default-x="10.00" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>up</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="start" default-y="-32.13">gliss.</glissando>
+          </notations>
+        </note>
+      <note default-x="108.84" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>1</voice>
+        <type>half</type>
+        <stem>down</stem>
+        <notations>
+          <glissando line-type="wavy" number="1" type="stop"/>
+          </notations>
+        </note>
+      </measure>
+    <measure number="24" width="201.70">
+      <note default-x="10.00" default-y="-10.00">
+        <pitch>
+          <step>D</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <backup>
+        <duration>384</duration>
+        </backup>
+      <note default-x="12.96" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="106.35" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      </measure>
+    <measure number="25" width="265.75">
+      <note default-x="15.02" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>384</duration>
+        <voice>1</voice>
+        <type>whole</type>
+        </note>
+      <backup>
+        <duration>384</duration>
+        </backup>
+      <note default-x="10.36" default-y="-25.00">
+        <pitch>
+          <step>A</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <note default-x="137.07" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>192</duration>
+        <voice>2</voice>
+        <type>half</type>
+        <stem>down</stem>
+        </note>
+      <backup>
+        <duration>384</duration>
+        </backup>
+      <note default-x="21.66" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>3</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="74.08" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>3</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="142.09" default-y="-45.00">
+        <pitch>
+          <step>D</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>3</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      <note default-x="200.79" default-y="-35.00">
+        <pitch>
+          <step>F</step>
+          <octave>4</octave>
+          </pitch>
+        <duration>96</duration>
+        <voice>3</voice>
+        <type>quarter</type>
+        <stem>up</stem>
+        </note>
+      </measure>
+    <measure number="26" width="185.92">
+      <note>
+        <rest/>
+        <duration>384</duration>
+        <voice>1</voice>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/Engine.Tests/Assets/Full_Identification.musicxml
+++ b/Engine.Tests/Assets/Full_Identification.musicxml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-number>Work Number</work-number>
+    <work-title>Work Title</work-title>
+    </work>
+    <movement-number>Movement Number</movement-number>
+    <movement-title>Movement Title</movement-title>
+    <identification>
+    <creator type="creator-key-a">creator value a</creator>
+    <creator type="creator-key-b">creator value b</creator>
+    <creator type="creator-key-c"></creator>
+    <creator>Ludwig van Beethoven</creator>
+    <rights>Sample Copyright</rights>
+    <rights type="rights-key-a">rights value a</rights>
+    <rights type="rights-key-b">rights value b</rights>
+    <encoding>
+      <software>Finale 2012 for Windows</software>
+      <software>Dolet Light for Finale 2012</software>
+      <encoding-description>MusicXML 3.0 example</encoding-description>
+      <encoding-date>2012-09-06</encoding-date>
+      <encoding-date>2012-09-09</encoding-date>
+      <encoder>Michael Good</encoder>
+      <supports attribute="new-system" element="print" type="yes" value="yes"/>
+      <supports attribute="new-page" element="print" type="yes" value="yes"/>
+    </encoding>
+    <miscellaneous>
+      <miscellaneous-field>Misc value without key</miscellaneous-field>
+      <miscellaneous-field name="misc-key-1">Misc value 1</miscellaneous-field>
+      <miscellaneous-field name="misc-key-2">Misc value 2</miscellaneous-field>
+    </miscellaneous>
+    <source>Source Description</source>
+  </identification>
+  <credit page="1">
+    <credit-words default-x="612" default-y="1527.31" justify="center" valign="top" font-size="24">Etude No. 1</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1167.31" default-y="1427.31" justify="right" valign="bottom" font-size="12">Alan Turing</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="133.88">
+      <attributes>
+        <divisions>96</divisions>
+        </attributes>
+      </measure>
+    </part>
+  </score-partwise>

--- a/Engine.Tests/Assets/Multi_Voice_Grand_Staff_Excerpt.musicxml
+++ b/Engine.Tests/Assets/Multi_Voice_Grand_Staff_Excerpt.musicxml
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE score-partwise PUBLIC "-//Recordare//DTD MusicXML 3.1 Partwise//EN" "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.1">
+  <work>
+    <work-title>Multi-Voice Grand Staff</work-title>
+    </work>
+  <identification>
+    <creator type="composer">Alan Turing</creator>
+    <encoding>
+      <software>MuseScore 3.2.3</software>
+      <encoding-date>2019-10-19</encoding-date>
+      <supports element="accidental" type="yes"/>
+      <supports element="beam" type="yes"/>
+      <supports element="print" attribute="new-page" type="yes" value="yes"/>
+      <supports element="print" attribute="new-system" type="yes" value="yes"/>
+      <supports element="stem" type="yes"/>
+      </encoding>
+    </identification>
+  <defaults>
+    <scaling>
+      <millimeters>7.05556</millimeters>
+      <tenths>40</tenths>
+      </scaling>
+    <page-layout>
+      <page-height>1683.78</page-height>
+      <page-width>1190.55</page-width>
+      <page-margins type="even">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      <page-margins type="odd">
+        <left-margin>56.6929</left-margin>
+        <right-margin>56.6929</right-margin>
+        <top-margin>56.6929</top-margin>
+        <bottom-margin>113.386</bottom-margin>
+        </page-margins>
+      </page-layout>
+    <word-font font-family="FreeSerif" font-size="10"/>
+    <lyric-font font-family="FreeSerif" font-size="11"/>
+    </defaults>
+  <credit page="1">
+    <credit-words default-x="595.275" default-y="1627.08" justify="center" valign="top" font-size="24">Multi-Voice Grand Staff</credit-words>
+    </credit>
+  <credit page="1">
+    <credit-words default-x="1133.86" default-y="1527.08" justify="right" valign="bottom" font-size="12">Alan Turing</credit-words>
+    </credit>
+  <part-list>
+    <score-part id="P1">
+      <part-name>Piano</part-name>
+      <part-abbreviation>Pno.</part-abbreviation>
+      <score-instrument id="P1-I1">
+        <instrument-name>Piano</instrument-name>
+        </score-instrument>
+      <midi-device id="P1-I1" port="1"></midi-device>
+      <midi-instrument id="P1-I1">
+        <midi-channel>1</midi-channel>
+        <midi-program>1</midi-program>
+        <volume>78.7402</volume>
+        <pan>0</pan>
+        </midi-instrument>
+      </score-part>
+    </part-list>
+  <part id="P1">
+    <measure number="1" width="319.35">
+      <print>
+        <system-layout>
+          <system-margins>
+            <left-margin>16.60</left-margin>
+            <right-margin>0.00</right-margin>
+            </system-margins>
+          <top-system-distance>170.00</top-system-distance>
+          </system-layout>
+        <staff-layout number="2">
+          <staff-distance>65.00</staff-distance>
+          </staff-layout>
+        </print>
+      <attributes>
+        <divisions>4</divisions>
+        <key>
+          <fifths>-3</fifths>
+          </key>
+        <time>
+          <beats>2</beats>
+          <beat-type>4</beat-type>
+          </time>
+        <staves>2</staves>
+        <clef number="1">
+          <sign>G</sign>
+          <line>2</line>
+          </clef>
+        <clef number="2">
+          <sign>F</sign>
+          <line>4</line>
+          </clef>
+        </attributes>
+      <note default-x="126.20" default-y="15.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note default-x="155.29" default-y="10.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="176.15" default-y="0.00">
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="217.86" default-y="10.00">
+        <pitch>
+          <step>A</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note default-x="238.72" default-y="5.00">
+        <pitch>
+          <step>G</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>1</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="267.81" default-y="-5.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>1</voice>
+        <type>eighth</type>
+        <stem>up</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        </note>
+      <backup>
+        <duration>8</duration>
+        </backup>
+      <note default-x="126.20" default-y="-15.00">
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        </note>
+      <note default-x="126.20" default-y="0.00">
+        <chord/>
+        <pitch>
+          <step>F</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <note default-x="176.15" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="217.86" default-y="-20.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">begin</beam>
+        </note>
+      <note default-x="267.81" default-y="-30.00">
+        <pitch>
+          <step>G</step>
+          <alter>-1</alter>
+          <octave>4</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <accidental>flat</accidental>
+        <stem>down</stem>
+        <staff>1</staff>
+        <beam number="1">end</beam>
+        </note>
+      <note default-x="267.81" default-y="-15.00">
+        <chord/>
+        <pitch>
+          <step>C</step>
+          <octave>5</octave>
+          </pitch>
+        <duration>2</duration>
+        <voice>2</voice>
+        <type>eighth</type>
+        <stem>down</stem>
+        <staff>1</staff>
+        </note>
+      <backup>
+        <duration>8</duration>
+        </backup>
+      <note default-x="126.20" default-y="-115.00">
+        <pitch>
+          <step>F</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note default-x="155.29" default-y="-120.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <accidental>flat</accidental>
+        <stem>down</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="176.15" default-y="-125.00">
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="197.00" default-y="-135.00">
+        <pitch>
+          <step>B</step>
+          <alter>-1</alter>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <stem>down</stem>
+        <staff>2</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <note default-x="217.86" default-y="-120.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">begin</beam>
+        <beam number="2">begin</beam>
+        </note>
+      <note default-x="238.72" default-y="-125.00">
+        <pitch>
+          <step>D</step>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="267.81" default-y="-120.00">
+        <pitch>
+          <step>E</step>
+          <alter>-1</alter>
+          <octave>3</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">continue</beam>
+        <beam number="2">continue</beam>
+        </note>
+      <note default-x="294.59" default-y="-140.00">
+        <pitch>
+          <step>A</step>
+          <octave>2</octave>
+          </pitch>
+        <duration>1</duration>
+        <voice>5</voice>
+        <type>16th</type>
+        <accidental>natural</accidental>
+        <stem>up</stem>
+        <staff>2</staff>
+        <beam number="1">end</beam>
+        <beam number="2">end</beam>
+        </note>
+      <barline location="right">
+        <bar-style>light-heavy</bar-style>
+        </barline>
+      </measure>
+    </part>
+  </score-partwise>

--- a/Engine.Tests/Engine.Tests.csproj
+++ b/Engine.Tests/Engine.Tests.csproj
@@ -22,11 +22,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Folder Include="Assets\" />
-  </ItemGroup>
-
-  <ItemGroup>
+    <None Update="Assets\Bare_Score_With_Skeleton.musicxml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\Bare_Score.musicxml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Assets\Etude_No._1.musicxml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\Full_Identification.musicxml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/Engine.Tests/Engine.Tests.csproj
+++ b/Engine.Tests/Engine.Tests.csproj
@@ -34,6 +34,9 @@
     <None Update="Assets\Full_Identification.musicxml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Assets\Multi_Voice_Grand_Staff_Excerpt.musicxml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/Engine.Tests/Engine.Tests.csproj
+++ b/Engine.Tests/Engine.Tests.csproj
@@ -21,4 +21,14 @@
     <ProjectReference Include="..\Engine\Engine.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="Assets\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Assets\Etude_No._1.musicxml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/Engine.Tests/MidiPitch.cs
+++ b/Engine.Tests/MidiPitch.cs
@@ -2,11 +2,98 @@ using MusicXmlSchema;
 using System;
 using Xunit;
 using SightReader.Engine.ScoreBuilder;
+using SightReader.Engine.Interpreter;
 using FluentAssertions;
 
 namespace SightReader.Engine.Tests
 {
-    public class MidiPitch
+    public class MidiPitchFromString
+    {
+        [Fact]
+        public void LowestNote()
+        {
+            "A0".ToPitch().Should().Be(21);
+        }
+
+        [Fact]
+        public void MiddleC()
+        {
+            "C4".ToPitch().Should().Be(60);
+        }
+
+        [Fact]
+        public void MiddleD()
+        {
+            "D4".ToPitch().Should().Be(62);
+        }
+
+        [Fact]
+        public void MiddleE()
+        {
+            "E4".ToPitch().Should().Be(64);
+        }
+
+        [Fact]
+        public void MiddleF()
+        {
+            "F4".ToPitch().Should().Be(65);
+        }
+
+        [Fact]
+        public void MiddleG()
+        {
+            "G4".ToPitch().Should().Be(67);
+        }
+
+        [Fact]
+        public void MiddleA()
+        {
+            "A4".ToPitch().Should().Be(69);
+        }
+
+        [Fact]
+        public void MiddleB()
+        {
+            "B4".ToPitch().Should().Be(71);
+        }
+
+        [Fact]
+        public void C5()
+        {
+            "C5".ToPitch().Should().Be(72);
+        }
+
+        [Fact]
+        public void MiddleCSharp()
+        {
+            "C#4".ToPitch().Should().Be(61);
+        }
+
+        [Fact]
+        public void MiddleDFlat()
+        {
+            "Db4".ToPitch().Should().Be(61);
+        }
+
+        [Fact]
+        public void MiddleDDoubleFlat()
+        {
+            "Dbb4".ToPitch().Should().Be(60);
+        }
+
+        [Fact]
+        public void MiddleCDoubleSharp()
+        {
+            "C##4".ToPitch().Should().Be(62);
+        }
+
+        [Fact]
+        public void HighestNote()
+        {
+            "C8".ToPitch().Should().Be(108);
+        }
+    }
+    public class MidiPitchFromMusicXml
     {
         [Fact]
         public void LowestNote()

--- a/Engine.Tests/ScoreBuilder.cs
+++ b/Engine.Tests/ScoreBuilder.cs
@@ -130,5 +130,111 @@ namespace SightReader.Engine.Tests
                 },
             });
         }
+
+        [Fact]
+        public void CanBuildFullFeaturedSingleStaffMusicXml()
+        {
+            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Etude_No._1.musicxml", FileMode.Open));
+            var score = builder.Build();
+
+            score.Parts.Should().ContainSingle();
+            score.Parts.First().Staves.Should().HaveCount(1);
+
+            var staff = score.Parts.First().Staves.First();
+
+            staff.Elements[0].Should().BeEquivalentTo(new Element()
+            {
+                Pitch = "C4".ToPitch(),
+                IsChordChild = false,
+                Measure = 1,
+                Staff = 1,
+                Voice = 1,
+                Duration = 384m
+            });
+
+            var noteWithTrill = staff.Elements.SelectMany(x => x.Where(y => y.Notations.OfType<Trill>().Count() > 0)
+            ).First();
+            noteWithTrill.Measure.Should().Be(13);
+            noteWithTrill.Pitch.Should().Be("G4".ToPitch());
+
+            var noteWithTurn = staff.Elements.SelectMany(x => x.Where(y => y.Notations.OfType<Turn>().Count() > 0)
+            ).First();
+            noteWithTurn.Measure.Should().Be(14);
+            noteWithTurn.Notations[0].As<Turn>().IsInverted = false;
+            noteWithTurn.Pitch.Should().Be("A4".ToPitch());
+
+            var noteWithInvertedTurn = staff.Elements.SelectMany(x => x.Where(y => y.Notations.OfType<Turn>().Count() > 0)
+            ).ElementAt(1);
+            noteWithInvertedTurn.Measure.Should().Be(15);
+            noteWithInvertedTurn.Notations[0].As<Turn>().IsInverted = true;
+            noteWithInvertedTurn.Pitch.Should().Be("B4".ToPitch());
+
+            var noteWithMordent = staff.Elements.SelectMany(x => x.Where(y => y.Notations.OfType<Mordent>().Count() > 0)
+            ).First();
+            noteWithMordent.Measure.Should().Be(16);
+            noteWithMordent.Notations[0].As<Mordent>().IsInverted = false;
+            noteWithMordent.Pitch.Should().Be("C5".ToPitch());
+
+            var noteWithInvertedMordent = staff.Elements.SelectMany(x => x.Where(y => y.Notations.OfType<Mordent>().Count() > 0)
+            ).ElementAt(1);
+            noteWithInvertedMordent.Measure.Should().Be(17);
+            noteWithInvertedMordent.Notations[0].As<Mordent>().IsInverted = true;
+            noteWithInvertedMordent.Pitch.Should().Be("C4".ToPitch());
+
+            var graceNote = staff.Elements.SelectMany(x => x.Where(y => y.IsGraceNote)).First();
+            graceNote.Measure.Should().Be(18);
+            graceNote.Pitch.Should().Be("D4".ToPitch());
+
+            var arpeggiatedGroups = staff.Elements.Where(x => x.Where(y => y.Notations.OfType<Arpeggiate>().Count() > 0).Count() > 0
+            ).ToArray();
+
+
+            var arpeggiatedDefault = arpeggiatedGroups[0].ToArray();
+            arpeggiatedGroups.Should().HaveCount(3);
+
+            arpeggiatedDefault[0].Measure.Should().Be(20);
+            arpeggiatedDefault[0].Pitch.Should().Be("C4".ToPitch());
+            arpeggiatedDefault[1].Pitch.Should().Be("E4".ToPitch());
+            arpeggiatedDefault[2].Pitch.Should().Be("G4".ToPitch());
+            arpeggiatedDefault[3].Pitch.Should().Be("C5".ToPitch());
+
+            var arpeggiatedUp = arpeggiatedGroups[1].ToArray();
+            arpeggiatedUp[0].Measure.Should().Be(21);
+            arpeggiatedUp[0].Pitch.Should().Be("D4".ToPitch());
+            arpeggiatedUp[1].Pitch.Should().Be("F4".ToPitch());
+            arpeggiatedUp[2].Pitch.Should().Be("A4".ToPitch());
+            arpeggiatedUp[3].Pitch.Should().Be("D5".ToPitch());
+
+            var arpeggiatedDown = arpeggiatedGroups[2].ToArray();
+            arpeggiatedDown[0].Measure.Should().Be(22);
+            arpeggiatedDown[0].Pitch.Should().Be("E4".ToPitch());
+            arpeggiatedDown[1].Pitch.Should().Be("G4".ToPitch());
+            arpeggiatedDown[2].Pitch.Should().Be("B4".ToPitch());
+            arpeggiatedDown[3].Pitch.Should().Be("E5".ToPitch());
+
+
+            var measureWithVoices = staff.Elements.Where(x => x.Where(y => y.Measure == 25).Count() > 0
+            ).ToArray();
+            measureWithVoices.Should().HaveCount(4);
+
+            measureWithVoices[0][0].Pitch.Should().Be("D4".ToPitch());
+            measureWithVoices[0][0].Voice.Should().Be(3);
+            measureWithVoices[0][1].Pitch.Should().Be("A4".ToPitch());
+            measureWithVoices[0][1].Voice.Should().Be(2);
+            measureWithVoices[0][2].Pitch.Should().Be("E5".ToPitch());
+            measureWithVoices[0][2].Voice.Should().Be(1);
+
+            measureWithVoices[1][0].Pitch.Should().Be("F4".ToPitch());
+            measureWithVoices[1][0].Voice.Should().Be(3);
+
+            measureWithVoices[2][0].Pitch.Should().Be("D4".ToPitch());
+            measureWithVoices[2][0].Voice.Should().Be(3);
+            measureWithVoices[2][1].Pitch.Should().Be("C5".ToPitch());
+            measureWithVoices[2][1].Voice.Should().Be(2);
+
+            measureWithVoices[3][0].Pitch.Should().Be("F4".ToPitch());
+            measureWithVoices[3][0].Voice.Should().Be(3);
+
+        }
     }
 }

--- a/Engine.Tests/ScoreBuilder.cs
+++ b/Engine.Tests/ScoreBuilder.cs
@@ -1,0 +1,20 @@
+using MusicXmlSchema;
+using System;
+using Xunit;
+using SightReader.Engine.ScoreBuilder;
+using FluentAssertions;
+using System.IO;
+using SightReader.Engine.Interpreter;
+
+namespace SightReader.Engine.Tests
+{
+    public class ScoreBuilderTests
+    {
+        [Fact]
+        public void CanBuildValidMusicXml()
+        {
+            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Etude_No._1.musicxml", FileMode.Open));
+            var score = builder.Build();
+        }
+    }
+}

--- a/Engine.Tests/ScoreBuilder.cs
+++ b/Engine.Tests/ScoreBuilder.cs
@@ -236,5 +236,67 @@ namespace SightReader.Engine.Tests
             measureWithVoices[3][0].Voice.Should().Be(3);
 
         }
+
+        [Fact]
+        public void CanBuildMultiVoiceGrandStaffExcerptMusicXml()
+        {
+            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Multi_Voice_Grand_Staff_Excerpt.musicxml", FileMode.Open));
+            var score = builder.Build();
+
+            score.Parts.Should().ContainSingle();
+            score.Parts.First().Staves.Should().HaveCount(2);
+
+            var treble = score.Parts.First().Staves.First().Elements;
+            var bass = score.Parts.First().Staves[1].Elements;
+
+            treble.Should().HaveCount(6);
+            treble[0][0].Pitch.Should().Be("C5".ToPitch());
+            treble[0][0].Voice.Should().Be(2);
+            treble[0][1].Pitch.Should().Be("F5".ToPitch());
+            treble[0][1].Voice.Should().Be(2);
+            treble[0][2].Pitch.Should().Be("Bb5".ToPitch());
+            treble[0][2].Voice.Should().Be(1);
+
+            treble[1][0].Pitch.Should().Be("Ab5".ToPitch());
+            treble[1][0].Voice.Should().Be(1);
+
+            treble[2][0].Pitch.Should().Be("Bb4".ToPitch());
+            treble[2][0].Voice.Should().Be(2);
+            treble[2][1].Pitch.Should().Be("F5".ToPitch());
+            treble[2][1].Voice.Should().Be(1);
+
+            treble[3][0].Pitch.Should().Be("Bb4".ToPitch());
+            treble[3][0].Voice.Should().Be(2);
+            treble[3][1].Pitch.Should().Be("Ab5".ToPitch());
+            treble[3][1].Voice.Should().Be(1);
+
+            treble[4][0].Pitch.Should().Be("G5".ToPitch());
+            treble[4][0].Voice.Should().Be(1);
+
+            treble[5][0].Pitch.Should().Be("Gb4".ToPitch());
+            treble[5][0].Voice.Should().Be(2);
+            treble[5][1].Pitch.Should().Be("C5".ToPitch());
+            treble[5][1].Voice.Should().Be(2);
+            treble[5][2].Pitch.Should().Be("Eb5".ToPitch());
+            treble[5][2].Voice.Should().Be(1);
+
+            bass.Should().HaveCount(8);
+            bass[0][0].Pitch.Should().Be("F3".ToPitch());
+            bass[0][0].Voice.Should().Be(5);
+            bass[1][0].Pitch.Should().Be("Eb3".ToPitch());
+            bass[1][0].Voice.Should().Be(5);
+            bass[2][0].Pitch.Should().Be("D3".ToPitch());
+            bass[2][0].Voice.Should().Be(5);
+            bass[3][0].Pitch.Should().Be("Bb2".ToPitch());
+            bass[3][0].Voice.Should().Be(5);
+            bass[4][0].Pitch.Should().Be("Eb3".ToPitch());
+            bass[4][0].Voice.Should().Be(5);
+            bass[5][0].Pitch.Should().Be("D3".ToPitch());
+            bass[5][0].Voice.Should().Be(5);
+            bass[6][0].Pitch.Should().Be("Eb3".ToPitch());
+            bass[6][0].Voice.Should().Be(5);
+            bass[7][0].Pitch.Should().Be("A2".ToPitch());
+            bass[7][0].Voice.Should().Be(5);
+        }
     }
 }

--- a/Engine.Tests/ScoreBuilder.cs
+++ b/Engine.Tests/ScoreBuilder.cs
@@ -5,16 +5,130 @@ using SightReader.Engine.ScoreBuilder;
 using FluentAssertions;
 using System.IO;
 using SightReader.Engine.Interpreter;
+using System.Linq;
 
 namespace SightReader.Engine.Tests
 {
     public class ScoreBuilderTests
     {
-        [Fact]
-        public void CanBuildValidMusicXml()
+        private void AssertScoreIsEmpty(Score score)
         {
-            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Etude_No._1.musicxml", FileMode.Open));
+            score.Info.WorkTitle.Should().BeEmpty();
+            score.Info.WorkNumber.Should().BeEmpty();
+            score.Info.MovementTitle.Should().BeEmpty();
+            score.Info.MovementNumber.Should().BeEmpty();
+            score.Info.Creators.Should().BeEmpty();
+            score.Info.Credits.Should().BeEmpty();
+            score.Info.EncodingDates.Should().BeEmpty();
+            score.Info.EncodingSoftware.Should().BeEmpty();
+            score.Info.Misc.Should().BeEmpty();
+            score.Info.Rights.Should().BeEmpty();
+            score.Info.Source.Should().BeEmpty();
+
+            score.Parts.Should().ContainSingle();
+            score.Parts.First().Staves.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void CanBuildBareScoreMusicXml()
+        {
+            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Bare_Score.musicxml", FileMode.Open));
             var score = builder.Build();
+
+            AssertScoreIsEmpty(score);
+        }
+
+        [Fact]
+        public void CanBuildBareScoreWithSkeletonMusicXml()
+        {
+            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Bare_Score_With_Skeleton.musicxml", FileMode.Open));
+            var score = builder.Build();
+
+            AssertScoreIsEmpty(score);
+        }
+
+        [Fact]
+        public void CanBuildFullIdentificationMusicXml()
+        {
+            var builder = new ScoreBuilder.ScoreBuilder(new FileStream(@"Assets\Full_Identification.musicxml", FileMode.Open));
+            var score = builder.Build();
+
+            score.Info.WorkTitle.Should().Be("Work Title");
+            score.Info.WorkNumber.Should().Be("Work Number");
+            score.Info.MovementTitle.Should().Be("Movement Title");
+            score.Info.MovementNumber.Should().Be("Movement Number");
+            score.Info.Source.Should().Be("Source Description");
+            score.Info.Creators.Should().BeEquivalentTo(new ScoreCreator[]{
+                new ScoreCreator()
+                {
+                    Type= "creator-key-a",
+                    Name = "creator value a",
+                },
+                new ScoreCreator()
+                {
+                    Type= "creator-key-b",
+                    Name = "creator value b",
+                },
+                new ScoreCreator()
+                {
+                    Type= "creator-key-c",
+                    Name = "", /* No XML value */
+                },
+                new ScoreCreator()
+                {
+                    Type = "", /* No creator type specified */
+                    Name = "Ludwig van Beethoven",
+                }
+            });
+            score.Info.Rights.Should().BeEquivalentTo(new ScoreRights[]{
+                new ScoreRights()
+                {
+                    Type= "",
+                    Content = "Sample Copyright",
+                },
+                new ScoreRights()
+                {
+                    Type= "rights-key-a",
+                    Content = "rights value a",
+                },
+                new ScoreRights()
+                {
+                    Type= "rights-key-b",
+                    Content = "rights value b",
+                },
+            });
+            score.Info.EncodingSoftware.Should().BeEquivalentTo(new string[]
+            {
+                "Finale 2012 for Windows",
+                "Dolet Light for Finale 2012"
+            });
+            score.Info.EncodingDates.Should().BeEquivalentTo(new DateTime[]
+            {
+                DateTime.Parse("2012-09-06"),
+                DateTime.Parse("2012-09-09"),
+            });
+            score.Info.Credits.Should().BeEquivalentTo(new string[]
+            {
+                "Etude No. 1",
+                "Alan Turing",
+            });
+            score.Info.Misc.Should().BeEquivalentTo(new ScoreMisc[]{
+                new ScoreMisc()
+                {
+                    Key = "",
+                    Value = "Misc value without key"
+                },
+                new ScoreMisc()
+                {
+                    Key = "misc-key-1",
+                    Value = "Misc value 1"
+                },
+                new ScoreMisc()
+                {
+                    Key = "misc-key-2",
+                    Value = "Misc value 2"
+                },
+            });
         }
     }
 }

--- a/Engine/Interpreter/Element.cs
+++ b/Engine/Interpreter/Element.cs
@@ -1,46 +1,95 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
+using SightReader.Engine.ScoreBuilder;
 
 namespace SightReader.Engine.Interpreter
 {
+    public static class StringExtensions
+    {
+        public static byte ToPitch(this string s)
+        {
+            byte OCTAVE_SEMITONES = 12;
+            byte C0_VALUE = 12; /* MIDI defines C0 as 12 */
+            byte octave = s.Last().ToString().ToByte();
+
+            byte valueForOctave = (byte)(C0_VALUE + octave * OCTAVE_SEMITONES);
+
+            byte stepSemitone = s.First() switch
+            {
+                'C' => 0,
+                'D' => 2,
+                'E' => 4,
+                'F' => 5,
+                'G' => 7,
+                'A' => 9,
+                'B' => 11,
+                _ => throw new NotSupportedException($"Received a string pitch to parse with a step of {s.First().ToString()}")
+            };
+
+            var isAlterSpecified = s.Length > 2;
+
+            var numberOfSharps = s.Count(x => x == '#');
+            var numberOfFlats = s.Count(x => x == 'b');
+
+            var alterSemitoneForSharps = numberOfSharps;
+            var alterSemitoneForFlats = -numberOfFlats;
+
+            return (byte)(valueForOctave + stepSemitone + alterSemitoneForSharps + alterSemitoneForFlats);
+        }
+    }
+
     public interface IElement
     {
+        decimal Duration { get; set; }
+        byte Voice { get; set; }
+        byte Staff { get; set; }
+        ushort Measure { get; set; }
+        byte Pitch { get; set; }
+        bool IsChordChild { get; set; }
+        bool IsGraceNote { get; set; }
+        bool IsRest { get; set; }
+        INotation[] Notations { get; set; }
     }
 
-    public enum NoteType
+    public class Element : IElement
     {
-        /**
-         * A regular note.
-         */
-        Default,
-        /**
-         * A grace note.
-         */
-        Grace,
+        private byte staff = 1;
+        private byte voice = 1;
 
-    }
-
-    /**
-     * https://usermanuals.musicxml.com/MusicXML/Content/EL-MusicXML-note.htm
-     */
-    public class Note : IElement
-    {
-        public NoteType Type { get; set; } = NoteType.Default;
-        public byte Pitch { get; set; }
         /**
          * Duration is a positive number specified in division units. This is the intended duration vs. notated duration (for instance, swing eighths vs. even eighths, or differences in dotted notes in Baroque-era music). Differences in duration specific to an interpretation or performance should use the note element's attack and release attributes.
          */
         public decimal Duration { get; set; }
-        public byte Voice { get; set; }
-        public byte Staff { get; set; }
-        public bool IsChordNote { get; set; }
-        public ushort Measure { get; set; }
-        public INotation[] Notations { get; set; } = new INotation[] { };
-    }
+        public byte Voice
+        {
+            get
+            {
+                return voice;
+            }
+            set
+            {
+                voice = value == 0 ? (byte)1 : value;
+            }
+        }
 
-    public class Chord : IElement
-    {
-        public Note[] Notes { get; set; } = new Note[] { };
+        public byte Staff
+        {
+            get
+            {
+                return staff;
+            }
+            set
+            {
+                staff = value == 0 ? (byte)1 : value;
+            }
+        }
+        public ushort Measure { get; set; }
+        public byte Pitch { get; set; }
+        public bool IsChordChild { get; set; }
+        public bool IsGraceNote { get; set; }
+        public bool IsRest { get; set; }
+        public INotation[] Notations { get; set; } = new INotation[] { };
     }
 }

--- a/Engine/Interpreter/Score.cs
+++ b/Engine/Interpreter/Score.cs
@@ -13,8 +13,8 @@ namespace SightReader.Engine.Interpreter
 
     public class ScoreRights
     {
-        public string Type { get; set;  } = "";
-        public string Content { get; set;  } = "";
+        public string Type { get; set; } = "";
+        public string Content { get; set; } = "";
     }
 
     public class ScoreMisc
@@ -41,16 +41,28 @@ namespace SightReader.Engine.Interpreter
     public class Part
     {
         public string Id { get; set; } = "";
-        public string Name { get; set;  } = "";
+        public string Name { get; set; } = "";
 
         public Staff[] Staves { get; set; } = new Staff[] { };
     }
 
     public class Staff
     {
-        public IElement[] Elements { get; set; } = new IElement[] { };
+        private int number;
+
+        public IElement[][] Elements { get; set; } = new IElement[][] { };
         public IDirective[] Directives { get; set; } = new IDirective[] { };
-        public int Number { get; set; } = 1;
+        public int Number
+        {
+            get
+            {
+                return number;
+            }
+            set
+            {
+                number = value == 0 ? 1 : value;
+            }
+        }
     }
 
     public interface IDirective { }

--- a/Engine/ScoreBuilder/ScoreBuilder.cs
+++ b/Engine/ScoreBuilder/ScoreBuilder.cs
@@ -110,7 +110,7 @@ namespace SightReader.Engine.ScoreBuilder
             return builtScore;
         }
 
-        public ScoreInfo BuildScoreInfo(scorepartwise rawScore) => new ScoreInfo()
+        private ScoreInfo BuildScoreInfo(scorepartwise rawScore) => new ScoreInfo()
         {
             WorkTitle = rawScore.work.worktitle,
             WorkNumber = rawScore.work.worknumber,
@@ -128,7 +128,7 @@ namespace SightReader.Engine.ScoreBuilder
             EncodingDates = rawScore.identification.encoding.Items.Length > 0 ? rawScore.identification.encoding.Items.Where((x, i) => rawScore.identification.encoding.ItemsElementName[i] == ItemsChoiceType.encodingdate).OfType<DateTime>().ToArray() : new DateTime[] { },
         };
 
-        public Staff[] BuildPartStaves(scorepartwise rawScore, scorepartwisePartMeasure[] measures)
+        private Staff[] BuildPartStaves(scorepartwise rawScore, scorepartwisePartMeasure[] measures)
         {
             var staves = new List<Staff>(4)
             {
@@ -148,7 +148,7 @@ namespace SightReader.Engine.ScoreBuilder
             return staves.ToArray();
         }
 
-        public void BuildPartStaffMeasure(scorepartwisePartMeasure measure, List<Staff> staves, List<BeatDurationDirective> beatDurationDirectives, List<RepeatDirective> repeatDirectives)
+        private void BuildPartStaffMeasure(scorepartwisePartMeasure measure, List<Staff> staves, List<BeatDurationDirective> beatDurationDirectives, List<RepeatDirective> repeatDirectives)
         {
             var measureNumber = measure.number.ToInt();
             var staffBuilders = new StaffBuilder[] {
@@ -203,7 +203,7 @@ namespace SightReader.Engine.ScoreBuilder
             }
         }
 
-        public void BuildPartStaffMeasureAttributes(attributes attributes, List<BeatDurationDirective> beatDurationDirectives, int measureNumber)
+        private void BuildPartStaffMeasureAttributes(attributes attributes, List<BeatDurationDirective> beatDurationDirectives, int measureNumber)
         {
             if (attributes.divisionsSpecified)
             {
@@ -224,7 +224,7 @@ namespace SightReader.Engine.ScoreBuilder
             }
         }
 
-        public void BuildPartStaffMeasureBarline(barline barline, List<RepeatDirective> repeatDirectives, int measureNumber)
+        private void BuildPartStaffMeasureBarline(barline barline, List<RepeatDirective> repeatDirectives, int measureNumber)
         {
             switch (barline.repeat.direction)
             {
@@ -244,7 +244,7 @@ namespace SightReader.Engine.ScoreBuilder
             }
         }
 
-        public Note BuildPartStaffMeasureElement(note rawNote, List<Staff> staves, int measureNumber)
+        private Note BuildPartStaffMeasureElement(note rawNote, List<Staff> staves, int measureNumber)
         {
             var note = new Note();
             var notations = new List<INotation>();
@@ -277,7 +277,7 @@ namespace SightReader.Engine.ScoreBuilder
             return note;
         }
 
-        public void BuildPartStaffMeasureElementNotations(notations[] rawNotations, List<INotation> notations)
+        private void BuildPartStaffMeasureElementNotations(notations[] rawNotations, List<INotation> notations)
         {
             foreach (var rawNotation in rawNotations)
             {
@@ -350,7 +350,7 @@ namespace SightReader.Engine.ScoreBuilder
             }
         }
 
-        public void BuildPartStaffMeasureElementArticulations(articulations rawArticulations, List<INotation> notations)
+        private void BuildPartStaffMeasureElementArticulations(articulations rawArticulations, List<INotation> notations)
         {
             for (int i = 0; i < rawArticulations.Items.Length; i++)
             {
@@ -404,7 +404,7 @@ namespace SightReader.Engine.ScoreBuilder
             }
         }
 
-        public void BuildPartStaffMeasureElementOrnaments(ornaments ornaments, List<INotation> notations)
+        private void BuildPartStaffMeasureElementOrnaments(ornaments ornaments, List<INotation> notations)
         {
             for (int i = 0; i < ornaments.Items.Length; i++)
             {

--- a/Engine/ScoreBuilder/ScoreBuilder.cs
+++ b/Engine/ScoreBuilder/ScoreBuilder.cs
@@ -317,7 +317,15 @@ namespace SightReader.Engine.ScoreBuilder
             var notations = new List<INotation>();
 
             el.Measure = (ushort)measureNumber;
-            el.Voice = rawNote.voice.ToByte();
+            
+            if (rawNote.staff != null)
+            {
+                el.Staff = rawNote.staff.ToByte();
+            }
+            if (rawNote.voice != null)
+            {
+                el.Voice = rawNote.voice.ToByte();
+            }
 
             if (rawNote.notations != null)
             {

--- a/Engine/ScoreBuilder/StaffBuilder.cs
+++ b/Engine/ScoreBuilder/StaffBuilder.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Linq;
 
 namespace SightReader.Engine.ScoreBuilder
 {
@@ -9,7 +10,8 @@ namespace SightReader.Engine.ScoreBuilder
     {
         public int StaffNumber { get; }
         private decimal clock = 0;
-        private Dictionary<decimal, Dictionary<byte, Note>> notes = new Dictionary<decimal, Dictionary<byte, Note>>();
+        private SortedDictionary<decimal, SortedDictionary<byte, Element>> notes = new SortedDictionary<decimal, SortedDictionary<byte, Element>>();
+        private Element previousEl = new Element();
 
         public StaffBuilder(int staffNumber)
         {
@@ -19,16 +21,42 @@ namespace SightReader.Engine.ScoreBuilder
         /**
          * Adds a note and advances the clock time if the note isn't part of a chord.
          */
-        public void AddNote(Note note)
+        public void ProcessNote(Element el)
         {
-            var existingNotes = notes[clock] ?? new Dictionary<byte, Note>();
-            existingNotes[note.Pitch] = note;
+            var isStartingChord = el.IsChordChild && !previousEl.IsChordChild;
+            var wasChordEnded = previousEl.IsChordChild && !el.IsChordChild;
+            var shouldRewindLastAppliedDuration = isStartingChord;
+            var shouldForwardLastUnappliedDuration = wasChordEnded;
+            var shouldAdvanceClock = !el.IsChordChild;
 
-            var shouldNoteAdvanceClock = !note.IsChordNote && note.Staff == StaffNumber;
-            if (shouldNoteAdvanceClock)
+            if (shouldRewindLastAppliedDuration)
             {
-                AdvanceClock(note.Duration);
+                RewindClock(previousEl.Duration);
             }
+            if (shouldForwardLastUnappliedDuration)
+            {
+                AdvanceClock(previousEl.Duration);
+            }
+
+            if (el.Staff == StaffNumber)
+            {
+                AddElement(el);
+            }
+
+            if (shouldAdvanceClock) {
+                AdvanceClock(el.Duration);
+            }
+
+            previousEl = el;
+        }
+
+        private void AddElement(Element el)
+        {
+            if (!notes.ContainsKey(clock))
+            {
+                notes[clock] = new SortedDictionary<byte, Element>();
+            }
+            notes[clock][el.Pitch] = el;
         }
 
         public void AdvanceClock(decimal forwardBy)
@@ -39,6 +67,11 @@ namespace SightReader.Engine.ScoreBuilder
         public void RewindClock(decimal rewindBy)
         {
             clock -= rewindBy;
+        }
+
+        public IEnumerable<List<IElement>> GetElements()
+        {
+            return notes.Values.Select(x => x.Values.Where(y => !y.IsRest).ToList<IElement>());
         }
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1015970/67148192-63ebd100-f238-11e9-9a4e-851457776491.png)
![image](https://user-images.githubusercontent.com/1015970/67148201-77973780-f238-11e9-9724-0b5d25d20545.png)

The program can correctly parse the pitches, voices, and groupings (elements grouped by beat) of every note in the first grand staff image and selected measures from the second single-staff example.

In the second single-staff example, notations like trill, arpeggiate (up/down), mordent (inverted/regular), and turn (inverted/regular) are correctly read.